### PR TITLE
chore: pin Node.js 24.x for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "keywords": [
     "gatsby"
   ],
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "develop": "gatsby develop",
     "start": "gatsby develop",


### PR DESCRIPTION
Vercel discontinued Node 18.x. Set engines.node so the build uses a supported runtime (overrides the dashboard Node version setting).