### PR TITLE
fix: pin Node.js 22.x instead of 24.x for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "gatsby"
   ],
   "engines": {
-    "node": "24.x"
+    "node": "22.x"
   },
   "scripts": {
     "develop": "gatsby develop",


### PR DESCRIPTION
Node 24 crashes gatsby build inside lmdb-datastore: Gatsby 5.13.2 bundles lmdb 2.5.3, which faults on Node 24. Node 22 (current LTS, still supported by Vercel) builds cleanly end-to-end.